### PR TITLE
Ajout Dérogation du mode programmé

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -292,15 +292,11 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "diag"
         capability["icon"] = "mdi:home-floor-2"
 
-    
     elif capabilityId == 157:
         capability["name"] = "prog_override"
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:clock-outline"
-    # elif capabilityId == 157:
-    #    # Prog override flag
-    #    return {}
 
     elif capabilityId == 158:
         if modelInfos["type"] == CozytouchDeviceType.TOWEL_RACK:

--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -292,6 +292,12 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "diag"
         capability["icon"] = "mdi:home-floor-2"
 
+    
+    elif capabilityId == 157:
+        capability["name"] = "prog_override"
+        capability["type"] = "switch"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:clock-outline"
     # elif capabilityId == 157:
     #    # Prog override flag
     #    return {}

--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -296,7 +296,7 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["name"] = "prog_override"
         capability["type"] = "switch"
         capability["category"] = "sensor"
-        capability["icon"] = "mdi:clock-outline"
+        capability["icon"] = "mdi:hand-back-left"
 
     elif capabilityId == 158:
         if modelInfos["type"] == CozytouchDeviceType.TOWEL_RACK:

--- a/custom_components/cozytouch/strings.json
+++ b/custom_components/cozytouch/strings.json
@@ -238,6 +238,7 @@
             "prog_heat_saturday":       { "name": "Saturday Heat prog" },
             "prog_heat_sunday":         { "name": "Sunday Heat prog" },
             "prog_mode":                { "name": "Prog Mode" },
+            "prog_override"             { "name": "Override" },
             "quiet_mode":               { "name": "Quiet Mode" },
             "radio_signal":             { "name": "Radio Signal" },
             "resistance":               { "name": "Resistance" },

--- a/custom_components/cozytouch/strings.json
+++ b/custom_components/cozytouch/strings.json
@@ -238,7 +238,7 @@
             "prog_heat_saturday":       { "name": "Saturday Heat prog" },
             "prog_heat_sunday":         { "name": "Sunday Heat prog" },
             "prog_mode":                { "name": "Prog Mode" },
-            "prog_override"             { "name": "Override" },
+            "prog_override":            { "name": "Override" },
             "quiet_mode":               { "name": "Quiet Mode" },
             "radio_signal":             { "name": "Radio Signal" },
             "resistance":               { "name": "Resistance" },

--- a/custom_components/cozytouch/translations/en.json
+++ b/custom_components/cozytouch/translations/en.json
@@ -238,6 +238,7 @@
             "prog_heat_saturday":       { "name": "Saturday Heat prog" },
             "prog_heat_sunday":         { "name": "Sunday Heat prog" },
             "prog_mode":                { "name": "Prog Mode" },
+            "prog_override":            { "name": "Override" },
             "quiet_mode":               { "name": "Quiet Mode" },
             "radio_signal":             { "name": "Radio Signal" },
             "resistance":               { "name": "Resistance" },
@@ -273,6 +274,7 @@
             "powerful_mode":      { "name": "Powerful Mode" },
             "presence_mode":      { "name": "Presence Mode" },
             "prog_mode":          { "name": "Prog Mode" },
+            "prog_override":      { "name": "Override" },
             "quiet_mode":         { "name": "Quiet Mode" },
             "swing_mode":         { "name": "Swing Mode" }
         }

--- a/custom_components/cozytouch/translations/fr.json
+++ b/custom_components/cozytouch/translations/fr.json
@@ -54,7 +54,7 @@
                         {
                             "basic": "Basique",
                             "prog": "Prog",
-                            "override": "Délégation"
+                            "override": "Dérogation"
                         }
                     },
                     "swing_mode":
@@ -80,7 +80,7 @@
                         {
                             "basic": "Basique",
                             "prog": "Prog",
-                            "override": "Délégation"
+                            "override": "Dérogation"
                         }
                     }
                 }
@@ -96,7 +96,7 @@
                         {
                             "basic": "Basique",
                             "prog": "Prog",
-                            "override": "Délégation"
+                            "override": "Dérogation"
                         }
                     }
                 }
@@ -112,7 +112,7 @@
                         {
                             "basic": "Basique",
                             "prog": "Prog",
-                            "override": "Délégation"
+                            "override": "Dérogation"
                         }
                     }
                 }
@@ -128,7 +128,7 @@
                         {
                             "basic": "Basique",
                             "prog": "Prog",
-                            "override": "Délégation"
+                            "override": "Dérogation"
                         }
                     }
                 }
@@ -140,9 +140,9 @@
         },
         "number": {
             "away_mode_temperature":    { "name": "Température Absence" },
-            "override_total_time":      { "name": "Durée Délégation" },
-            "override_total_time_z1":   { "name": "Durée Délégation Z1" },
-            "override_total_time_z2":   { "name": "Durée Délégation Z2" },
+            "override_total_time":      { "name": "Durée Dérogation" },
+            "override_total_time_z1":   { "name": "Durée Dérogation Z1" },
+            "override_total_time_z2":   { "name": "Durée Dérogation Z2" },
             "target_cool_temperature":  { "name": "Température Consigne Cool" },
             "target_temperature":       { "name": "Température Consigne" },
             "target_temperature_dhw":   { "name": "Température Consigne DHW" },
@@ -195,9 +195,9 @@
             "number_of_starts_dhw_pump":{ "name": "Nb démarrages pompe DHW" },
             "off_peak_hours":           { "name": "Heures Creuses" },
             "outside_temperature":      { "name": "Température Extérieure" },
-            "override_remain_time":     { "name": "Durée Délégation Restante" },
-            "override_remain_time_z1":  { "name": "Durée Délégation Restante Z1" },
-            "override_remain_time_z2":  { "name": "Durée Délégation Restante Z2" },
+            "override_remain_time":     { "name": "Durée Dérogation Restante" },
+            "override_remain_time_z1":  { "name": "Durée Dérogation Restante Z1" },
+            "override_remain_time_z2":  { "name": "Durée Dérogation Restante Z2" },
             "power_consumption":        { "name": "Consommation" },
             "powerful_mode":            { "name": "Mode Powerful" },
             "presence_mode":            { "name": "Mode Présence" },
@@ -238,6 +238,7 @@
             "prog_heat_saturday":       { "name": "Samedi Prog Heat" },
             "prog_heat_sunday":         { "name": "Dimanche Prog Heat" },
             "prog_mode":                { "name": "Mode Prog" },
+            "prog_override":            { "name": "Dérogation" },
             "quiet_mode":               { "name": "Mode Silence" },
             "radio_signal":             { "name": "Signal Radio" },
             "resistance":               { "name": "Résistance" },
@@ -273,6 +274,7 @@
             "powerful_mode":      { "name": "Mode Powerful" },
             "presence_mode":      { "name": "Mode Présence" },
             "prog_mode":          { "name": "Mode Prog" },
+            "prog_override":      { "name": "Dérogation" },
             "quiet_mode":         { "name": "Mode Silence" },
             "swing_mode":         { "name": "Mode Oscillation" }
         }


### PR DESCRIPTION
Bonjour, tout d'abord je vous remercie énormément pour votre travail qui m'a permis d'intégrer ma chaudière Atlantic Naia 2 micro 25 avec un Navilink 128 :pray:

Je suis débutant sur github et même git, et ceci serait ma toute première contribution à un projet. Je serais honoré et cela me ferait plaisir de voir mon nom apparaître dans le projet, je ne sais si le pull request le permet. Bref, merci si possible, sinon pas grave.

Voici ce qui m'amène : Le thermostat permet de déroger au mode programmé en fixant une température de consigne figée à une certaine valeur pendant une certaine durée.
Après plusieurs tests avec les capabilities connues, impossible d'appliquer une température de dérogation.
Après ajout des unknown capabilities, j'ai pu déduire que la capability 157 servait à activer la dérogation.
Je l'ai donc ajoutée et testée, cela fonctionne, je peux maintenant appliqué une température de dérogation.
J'ai ajouté les traductions et également profité pour renommer "délégation" en "dérogation" puisque ce sont les termes du manuel.

Lors de mes tests, j'ai remarqué que pour appliquer une température de dérogation, il fallait appliquer d'abord une durée de dérogation, sinon la dérogation n'est pas appliquée. Il serait peut être intéressant de le noter dans un manuel/guide du projet... ?

Je reste à votre disposition pour tout complément (il n'est pas exclu que j'ai mal fait quelque chose :grin: )
Et une très belle année à vous.