### PR TITLE
Add support for Sauter Asama Connecté II Ventilo 1750W Blanc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This has been tested using on :
   - `Atlantic Naema 2 Duo 25` gas boiler using a `Ǹavilink Radio-Connect 128` thermostat
   - `Takao M3` air conditionning
   - `Kelud 1750W` towel rack
+  - `Sauter Asama Connecté II Ventilo 1750W` towel rack
 
 A special mapping needs to be done for each model type, feel free to create an issue to help supporting your device.
 

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -248,6 +248,14 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
             4: HVACMode.HEAT,
         }
 
+    elif modelId == 1543:
+        modelInfos["name"] = "Asama Connecté II Ventilo 1750W Blanc"
+        modelInfos["type"] = CozytouchDeviceType.TOWEL_RACK
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
+            4: HVACMode.HEAT,
+        }
+
     else:
         modelInfos["name"] = "Unknown product (" + str(modelId) + ")"
         modelInfos["type"] = CozytouchDeviceType.UNKNOWN


### PR DESCRIPTION
Add support for model ID `1543`, Sauter [Asama Connecté II Ventilo 1750W Blanc](https://www.confort-sauter.com/chauffage/radiateurs-seche-serviettes/asama-connecte-ii-ventilo/asama-connecte-ii-ventilo-1750w-blanc).