### PR TITLE
Ignore capability 181

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -361,6 +361,10 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "diag"
         capability["icon"] = "mdi:wifi"
 
+    elif capabilityId == 181:
+        # Ignore, same as heat sensor (7, 8)
+        return {}
+
     elif capabilityId == 184:
         capability["name"] = "prog_mode"
         capability["type"] = "switch"


### PR DESCRIPTION
Ignore sensor for capability 181, which seems to be the same as `heat` for Sauter towel rack:
- 0 = `off`
- 4 = `heat`