### PR TITLE
Make maximum temperature setting adjustable

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -334,9 +334,12 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
     elif capabilityId == 161:
         # Target temperature adjustment max limit
         capability["name"] = "temperature_adjustment_max"
-        capability["type"] = "temperature"
+        capability["type"] = "temperature_adjustment_number"
         capability["category"] = "diag"
         capability["icon"] = "mdi:thermometer-chevron-up"
+        capability["lowest_value"] = 19
+        capability["highest_value"] = 28
+        capability["step"] = 0.5
 
     elif capabilityId == 165:
         capability["name"] = "boost_mode"

--- a/custom_components/cozytouch/number.py
+++ b/custom_components/cozytouch/number.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTime
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -104,10 +104,10 @@ class TemperatureAdjustmentNumber(NumberEntity, CozytouchSensor):
         )
         self._attr_device_class = NumberDeviceClass.TEMPERATURE
         self._attr_mode = "auto"
-        self._attr_native_step = 0.5
-        self._attr_native_unit_of_measurement = "°C"
-        self._attr_native_min_value = 0.0
-        self._attr_native_max_value = 60.0
+        self._attr_native_step = capability.get("step", 0.5)
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_native_min_value = capability.get("lowest_value", 0)
+        self._attr_native_max_value = capability.get("highest_value", 60.0)
         self._native_value = 0
 
     @property

--- a/custom_components/cozytouch/strings.json
+++ b/custom_components/cozytouch/strings.json
@@ -139,16 +139,17 @@
             "away_mode_stop":   { "name": "Away Mode Stop" }
         },
         "number": {
-            "away_mode_temperature":    { "name": "Away Mode Temperature" },
-            "boost_timeout_max":        { "name": "Boost Timeout Max." },
-            "override_total_time":      { "name": "Override Total Time" },
-            "override_total_time_z1":   { "name": "Override Total Time Z1" },
-            "override_total_time_z2":   { "name": "Override Total Time Z2" },
-            "target_cool_temperature":  { "name": "Target Cool Temperature" },
-            "target_temperature":       { "name": "Target Temperature" },
-            "target_temperature_dhw":   { "name": "Target Temperature DHW" },
-            "target_temperature_eco_z1":{ "name": "Target Temperature Eco Z1" },
-            "target_temperature_eco_z2":{ "name": "Target Temperature Eco Z2" }
+            "away_mode_temperature":      { "name": "Away Mode Temperature" },
+            "boost_timeout_max":          { "name": "Boost Timeout Max." },
+            "override_total_time":        { "name": "Override Total Time" },
+            "override_total_time_z1":     { "name": "Override Total Time Z1" },
+            "override_total_time_z2":     { "name": "Override Total Time Z2" },
+            "target_cool_temperature":    { "name": "Target Cool Temperature" },
+            "target_temperature":         { "name": "Target Temperature" },
+            "target_temperature_dhw":     { "name": "Target Temperature DHW" },
+            "target_temperature_eco_z1":  { "name": "Target Temperature Eco Z1" },
+            "target_temperature_eco_z2":  { "name": "Target Temperature Eco Z2" },
+            "temperature_adjustment_max": { "name": "Maximum Temperature" }
         },
         "select": {
             "heating_mode":
@@ -252,7 +253,6 @@
             "target_temperature_dhw":   { "name": "Target Temperature DHW" },
             "target_temperature_eco_z1":{ "name": "Target Temperature Eco Z1" },
             "target_temperature_eco_z2":{ "name": "Target Temperature Eco Z2" },
-            "temperature_adjustment_max": { "name": "Maximum Temperature" },
             "temperature_adjustment_min": { "name": "Minimum Temperature" },
             "thermostat_temperature_z1":{ "name": "Thermostat Temperature Z1" },
             "thermostat_temperature_z2":{ "name": "Thermostat Temperature Z2" },

--- a/custom_components/cozytouch/translations/en.json
+++ b/custom_components/cozytouch/translations/en.json
@@ -139,16 +139,17 @@
             "away_mode_stop":   { "name": "Away Mode Stop" }
         },
         "number": {
-            "away_mode_temperature":    { "name": "Away Mode Temperature" },
-            "boost_timeout_max":        { "name": "Boost Timeout Max." },
-            "override_total_time":      { "name": "Override Total Time" },
-            "override_total_time_z1":   { "name": "Override Total Time Z1" },
-            "override_total_time_z2":   { "name": "Override Total Time Z2" },
-            "target_cool_temperature":  { "name": "Target Cool Temperature" },
-            "target_temperature":       { "name": "Target Temperature" },
-            "target_temperature_dhw":   { "name": "Target Temperature DHW" },
-            "target_temperature_eco_z1":{ "name": "Target Temperature Eco Z1" },
-            "target_temperature_eco_z2":{ "name": "Target Temperature Eco Z2" }
+            "away_mode_temperature":      { "name": "Away Mode Temperature" },
+            "boost_timeout_max":          { "name": "Boost Timeout Max." },
+            "override_total_time":        { "name": "Override Total Time" },
+            "override_total_time_z1":     { "name": "Override Total Time Z1" },
+            "override_total_time_z2":     { "name": "Override Total Time Z2" },
+            "target_cool_temperature":    { "name": "Target Cool Temperature" },
+            "target_temperature":         { "name": "Target Temperature" },
+            "target_temperature_dhw":     { "name": "Target Temperature DHW" },
+            "target_temperature_eco_z1":  { "name": "Target Temperature Eco Z1" },
+            "target_temperature_eco_z2":  { "name": "Target Temperature Eco Z2" },
+            "temperature_adjustment_max": { "name": "Maximum Temperature" }
         },
         "select": {
             "heating_mode":
@@ -252,7 +253,6 @@
             "target_temperature_dhw":   { "name": "Target Temperature DHW" },
             "target_temperature_eco_z1":{ "name": "Target Temperature Eco Z1" },
             "target_temperature_eco_z2":{ "name": "Target Temperature Eco Z2" },
-            "temperature_adjustment_max": { "name": "Maximum Temperature" },
             "temperature_adjustment_min": { "name": "Minimum Temperature" },
             "thermostat_temperature_z1":{ "name": "Thermostat Temperature Z1" },
             "thermostat_temperature_z2":{ "name": "Thermostat Temperature Z2" },

--- a/custom_components/cozytouch/translations/fr.json
+++ b/custom_components/cozytouch/translations/fr.json
@@ -139,16 +139,17 @@
             "away_mode_stop":   { "name": "Absence Fin" }
         },
         "number": {
-            "away_mode_temperature":    { "name": "Température Absence" },
-            "boost_timeout_max":        { "name": "Temporisation Max. Boost" },
-            "override_total_time":      { "name": "Durée Délégation" },
-            "override_total_time_z1":   { "name": "Durée Délégation Z1" },
-            "override_total_time_z2":   { "name": "Durée Délégation Z2" },
-            "target_cool_temperature":  { "name": "Température Consigne Cool" },
-            "target_temperature":       { "name": "Température Consigne" },
-            "target_temperature_dhw":   { "name": "Température Consigne DHW" },
-            "target_temperature_eco_z1":{ "name": "Température Consigne Eco Z1" },
-            "target_temperature_eco_z2":{ "name": "Température Consigne Eco Z2" }
+            "away_mode_temperature":      { "name": "Température Absence" },
+            "boost_timeout_max":          { "name": "Temporisation Max. Boost" },
+            "override_total_time":        { "name": "Durée Délégation" },
+            "override_total_time_z1":     { "name": "Durée Délégation Z1" },
+            "override_total_time_z2":     { "name": "Durée Délégation Z2" },
+            "target_cool_temperature":    { "name": "Température Consigne Cool" },
+            "target_temperature":         { "name": "Température Consigne" },
+            "target_temperature_dhw":     { "name": "Température Consigne DHW" },
+            "target_temperature_eco_z1":  { "name": "Température Consigne Eco Z1" },
+            "target_temperature_eco_z2":  { "name": "Température Consigne Eco Z2" },
+            "temperature_adjustment_max": { "name": "Température Maximale" }
         },
         "select": {
             "heating_mode":
@@ -252,7 +253,6 @@
             "target_temperature_dhw":   { "name": "Température Consigne ECS" },
             "target_temperature_eco_z1":{ "name": "Température Consigne Eco Z1" },
             "target_temperature_eco_z2":{ "name": "Température Consigne Eco Z2" },
-            "temperature_adjustment_max": { "name": "Température Maximale" },
             "temperature_adjustment_min": { "name": "Température Minimale" },
             "thermostat_temperature_z1":{ "name": "Température Thermostat Z1" },
             "thermostat_temperature_z2":{ "name": "Température Thermostat Z2" },


### PR DESCRIPTION
Update Maximum Temperature setting (capability 161) to be an adjustable number (`temperature_adjustment_number`).

Add optional attributes `step`, `lowest_value` and `highest_value` to temperature_adjustment_number to enable hard-coded default values.

![Screenshot](https://github.com/user-attachments/assets/42cb590a-b025-4816-a1bf-3c1cd7949988)
