### PR TITLE
Ne pas utiliser PRESET_BASIC si PRESET_NONE existe

### DIFF
--- a/custom_components/cozytouch/climate.py
+++ b/custom_components/cozytouch/climate.py
@@ -178,7 +178,8 @@ class CozytouchClimate(ClimateEntity, CozytouchSensor):
             if "progOverrideCapabilityId" in self._capability:
                 self._attr_preset_modes.append(PRESET_OVERRIDE)
 
-            self._attr_preset_mode = PRESET_BASIC
+            if PRESET_NONE not in self._attr_preset_modes :
+                self._attr_preset_mode = PRESET_BASIC
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -335,7 +336,8 @@ class CozytouchClimate(ClimateEntity, CozytouchSensor):
                 )
             )
             if progModeValue == 0:
-                self._attr_preset_mode = PRESET_BASIC
+                if PRESET_NONE not in self._attr_preset_modes :
+                    self._attr_preset_mode = PRESET_BASIC
             elif "progOverrideCapabilityId" in self._capability:
                 # In prog mode we can also be in override mode
                 progOverrideValue = int(


### PR DESCRIPTION
J'avais un conflit avec PRESET_BASIC qui prenait le dessus sur PRESET_NONE / PRESET_ACTIVITY / PRESET_ECO / PRESET_BOOST ce qui ne facilite pas l'utilisation.

Cette modification permet lors de la sélection de PRESET_BASIC de revenir au mode normal et afficher PRESET_NONE / PRESET_ACTIVITY / PRESET_ECO / PRESET_BOOST selon ce qui existe et est activé.

Cependant PRESET_PROG et PRESET_OVERRIDE prennent le dessus si ils sont sélectionnés.