### PR TITLE
Add support for Atlantic Thermostat PRE (for electric underfloor heating)

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -68,6 +68,10 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
             capability.pop("lowestValueCapabilityId")
             capability.pop("highestValueCapabilityId")
             capability["icon"] = "mdi:heat-pump"
+        elif modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            capability["name"] = "heat"
+            capability["icon"] = "mdi:thermostat"
+            capability["targetCapabilityId"] = 40
         else:
             capability["name"] = "heat"
 
@@ -369,9 +373,8 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["highestValueCapabilityId"] = 161
 
     elif capabilityId == 177:
-        if modelInfos["type"] == CozytouchDeviceType.GAZ_BOILER:
+        if modelInfos["type"] in [CozytouchDeviceType.GAZ_BOILER, CozytouchDeviceType.THERMOSTAT]:
             return {}
-
         capability["name"] = "target_cool_temperature"
         capability["type"] = "temperature_adjustment_number"
         capability["category"] = "sensor"
@@ -623,21 +626,24 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["icon"] = "mdi:fire"
 
     elif capabilityId == 100505:
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "powerful_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:wind-power"
 
     elif capabilityId == 100506:
-        if modelInfos["type"] == CozytouchDeviceType.TOWEL_RACK:
-            capability = {}
-        else:
-            capability["name"] = "presence_mode"
-            capability["type"] = "switch"
-            capability["category"] = "sensor"
-            capability["icon"] = "mdi:account"
+        if modelInfos["type"] in [CozytouchDeviceType.TOWEL_RACK, CozytouchDeviceType.THERMOSTAT]:
+            return {}
+        capability["name"] = "presence_mode"
+        capability["type"] = "switch"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:account"
 
     elif capabilityId == 100507:
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "eco_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
@@ -714,18 +720,24 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "diag"
 
     elif capabilityId == 100802:
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "quiet_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:fan-minus"
 
     elif capabilityId == 100804:
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "swing_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:arrow-oscillating"
 
     elif capabilityId == 104044:
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "boost_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"

--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -7,6 +7,7 @@ import copy
 from datetime import UTC, datetime, time as t, timedelta, timezone
 import json
 import logging
+from typing import Any, Dict
 
 from aiohttp import ClientSession, ContentTypeError, FormData
 
@@ -328,7 +329,7 @@ class Hub(DataUpdateCoordinator):
 
         return str(zoneId)
 
-    def get_model_infos(self, deviceId: int | None = None) -> str:
+    def get_model_infos(self, deviceId: int | None = None) -> Dict[str, Any]:
         """Get model infos."""
         if not deviceId:
             deviceId = self._deviceId
@@ -336,6 +337,7 @@ class Hub(DataUpdateCoordinator):
         for dev in self._devices:
             if dev["deviceId"] == deviceId:
                 zoneId = dev["zoneId"]
+                tags = dev["tags"]
 
                 # Special case for sub-devices, use master zone Id
                 for masterDev in self._devices:
@@ -350,7 +352,7 @@ class Hub(DataUpdateCoordinator):
                                 zoneId = masterDev["zoneId"]
                                 break
 
-                return get_model_infos(dev["modelId"], self.get_zone_name(zoneId))
+                return get_model_infos(dev["modelId"], self.get_zone_name(zoneId), tags)
 
         return get_model_infos(-1)
 

--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -227,7 +227,7 @@ class Hub(DataUpdateCoordinator):
                     "modelId": remote_device["modelId"],
                     "productId": remote_device["productId"],
                     "zoneId": remote_device["zoneId"],
-                    "modelInfos": get_model_infos(remote_device["modelId"]),
+                    "modelInfos": get_model_infos(remote_device["modelId"], remote_device["tags"]),
                     "capabilities": [],
                     "tags": [],
                 }
@@ -329,7 +329,7 @@ class Hub(DataUpdateCoordinator):
 
         return str(zoneId)
 
-    def get_model_infos(self, deviceId: int | None = None) -> Dict[str, Any]:
+    def get_model_infos(self, deviceId: int | None = None) -> dict:
         """Get model infos."""
         if not deviceId:
             deviceId = self._deviceId
@@ -352,9 +352,9 @@ class Hub(DataUpdateCoordinator):
                                 zoneId = masterDev["zoneId"]
                                 break
 
-                return get_model_infos(dev["modelId"], self.get_zone_name(zoneId), tags)
+                return get_model_infos(dev["modelId"], tags, self.get_zone_name(zoneId))
 
-        return get_model_infos(-1)
+        return get_model_infos(-1, [])
 
     def get_serial_number(self, deviceId: int | None = None) -> str:
         """Get serial number."""
@@ -376,7 +376,7 @@ class Hub(DataUpdateCoordinator):
         capabilities = []
         for dev in self._devices:
             if dev["deviceId"] == deviceId:
-                modelInfos = get_model_infos(dev["modelId"])
+                modelInfos = get_model_infos(dev["modelId"], dev["tags"])
                 for capability in dev["capabilities"]:
                     capability_infos = get_capability_infos(
                         modelInfos,

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -18,6 +18,7 @@ Optional :
 """  # noqa: D205
 
 from enum import StrEnum
+from typing import Dict, List
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.components.climate.const import (
@@ -54,7 +55,7 @@ class CozytouchDeviceType(StrEnum):
     HUB = "hub"
 
 
-def get_model_infos(modelId: int, zoneName: str | None = None):
+def get_model_infos(modelId: int, zoneName: str | None = None, tags: List[Dict[str, str]] | None = None):
     """Return infos from model ID."""
     modelInfos = {"modelId": modelId, "HVACModesCapabilityId": {7, 8}}
 
@@ -186,38 +187,113 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
         }
 
     elif modelId >= 557 and modelId <= 561:
-        name = "Air Conditioner "
+        name = "Unknown product (" + str(modelId) + ")"
+        modelInfos["type"] = CozytouchDeviceType.UNKNOWN
+        # modelInfos["fanModes"] = {}
+        # modelInfos["swingModes"] = {}
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
+            4: HVACMode.HEAT,
+        }
+
+        childrenIds = []
+        for tag in tags if tags is not None else []:
+            if (
+                "label" in tag
+                and tag["label"] == "iothubChildrenIds"
+                and "value" in tag
+            ):
+                childrenIds = tag["value"].split(",")
+                break
+
+        if any(childId.startswith("UI_") for childId in childrenIds): # Air conditioner detected
+            name = "Air Conditioner "
+            modelInfos["type"] = CozytouchDeviceType.AC
+            modelInfos["currentTemperatureAvailable"] = False
+            modelInfos["quietModeAvailable"] = True
+
+            modelInfos["fanModes"] = {
+                1: FAN_LOW,
+                2: FAN_MEDIUM,
+                3: FAN_HIGH,
+                5: FAN_AUTO,
+            }
+
+            modelInfos["swingModes"] = {
+                1: SWING_MODE_UP,
+                2: SWING_MODE_MIDDLE_UP,
+                3: SWING_MODE_MIDDLE_DOWN,
+                4: SWING_MODE_DOWN,
+            }
+
+            modelInfos["HVACModes"] = {
+                0: HVACMode.OFF,
+                1: HVACMode.AUTO,
+                3: HVACMode.COOL,
+                4: HVACMode.HEAT,
+                7: HVACMode.FAN_ONLY,
+                8: HVACMode.DRY,
+            }
+        elif any(childId.startswith("THZONE_") for childId in childrenIds): # Thermostat detected
+            name = "Thermostat (THZONE) "
+            if zoneName is not None:
+                modelInfos["name"] = name + "(" + zoneName + ")"
+            else:
+                modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
+
+            modelInfos["type"] = CozytouchDeviceType.THERMOSTAT
+            modelInfos["currentTemperatureAvailable"] = False
+            modelInfos["currentTemperatureAvailableZ1"] = True
+            modelInfos["quietModeAvailable"] = False
+
+            modelInfos["HVACModes"] = {
+                0: HVACMode.OFF,
+                4: HVACMode.HEAT,
+            }
+            modelInfos["HeatingModes"] = {
+                0: HEATING_MODE_MANUAL,
+                3: HEATING_MODE_ECO_PLUS,
+                4: HEATING_MODE_PROG,
+            }
+        # else: # Fallback to AC if none found to keep backward compatibility
+        #     name = "Air Conditioner "
+        #     if zoneName is not None:
+        #         modelInfos["name"] = name + "(" + zoneName + ")"
+        #     else:
+        #         modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
+
+        #     modelInfos["type"] = CozytouchDeviceType.AC
+        #     modelInfos["currentTemperatureAvailable"] = False
+        #     modelInfos["quietModeAvailable"] = True
+
+        #     modelInfos["fanModes"] = {
+        #         1: FAN_LOW,
+        #         2: FAN_MEDIUM,
+        #         3: FAN_HIGH,
+        #         5: FAN_AUTO,
+        #     }
+
+        #     modelInfos["swingModes"] = {
+        #         1: SWING_MODE_UP,
+        #         2: SWING_MODE_MIDDLE_UP,
+        #         3: SWING_MODE_MIDDLE_DOWN,
+        #         4: SWING_MODE_DOWN,
+        #     }
+
+        #     modelInfos["HVACModes"] = {
+        #         0: HVACMode.OFF,
+        #         1: HVACMode.AUTO,
+        #         3: HVACMode.COOL,
+        #         4: HVACMode.HEAT,
+        #         7: HVACMode.FAN_ONLY,
+        #         8: HVACMode.DRY,
+        #     }
+
         if zoneName is not None:
             modelInfos["name"] = name + "(" + zoneName + ")"
         else:
             modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
 
-        modelInfos["type"] = CozytouchDeviceType.AC
-        modelInfos["currentTemperatureAvailable"] = False
-        modelInfos["quietModeAvailable"] = True
-
-        modelInfos["fanModes"] = {
-            1: FAN_LOW,
-            2: FAN_MEDIUM,
-            3: FAN_HIGH,
-            5: FAN_AUTO,
-        }
-
-        modelInfos["swingModes"] = {
-            1: SWING_MODE_UP,
-            2: SWING_MODE_MIDDLE_UP,
-            3: SWING_MODE_MIDDLE_DOWN,
-            4: SWING_MODE_DOWN,
-        }
-
-        modelInfos["HVACModes"] = {
-            0: HVACMode.OFF,
-            1: HVACMode.AUTO,
-            3: HVACMode.COOL,
-            4: HVACMode.HEAT,
-            7: HVACMode.FAN_ONLY,
-            8: HVACMode.DRY,
-        }
 
     elif modelId >= 562 and modelId <= 570:
         name = "Air Conditioner User Interface "
@@ -296,6 +372,18 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
         modelInfos["HVACModes"] = {
             0: HVACMode.OFF,
             4: HVACMode.HEAT,
+        }
+
+    elif modelId >= 1505 and modelId <= 1513:
+        name = "Thermostat Thermal Zone "
+        if zoneName is not None:
+            modelInfos["name"] = name + "(" + zoneName + ")"
+        else:
+            modelInfos["name"] = name + "(#" + str(modelId - 561) + ")"
+
+        modelInfos["type"] = CozytouchDeviceType.THERMOSTAT
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
         }
 
     elif modelId == 1543:

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -18,7 +18,7 @@ Optional :
 """  # noqa: D205
 
 from enum import StrEnum
-from typing import Dict, List
+import logging
 
 from homeassistant.components.climate import HVACMode
 from homeassistant.components.climate.const import (
@@ -55,7 +55,7 @@ class CozytouchDeviceType(StrEnum):
     HUB = "hub"
 
 
-def get_model_infos(modelId: int, zoneName: str | None = None, tags: List[Dict[str, str]] | None = None):
+def get_model_infos(modelId: int, tags: list, zoneName: str | None = None) -> dict:
     """Return infos from model ID."""
     modelInfos = {"modelId": modelId, "HVACModesCapabilityId": {7, 8}}
 
@@ -189,8 +189,6 @@ def get_model_infos(modelId: int, zoneName: str | None = None, tags: List[Dict[s
     elif modelId >= 557 and modelId <= 561:
         name = "Unknown product (" + str(modelId) + ")"
         modelInfos["type"] = CozytouchDeviceType.UNKNOWN
-        # modelInfos["fanModes"] = {}
-        # modelInfos["swingModes"] = {}
         modelInfos["HVACModes"] = {
             0: HVACMode.OFF,
             4: HVACMode.HEAT,
@@ -235,15 +233,18 @@ def get_model_infos(modelId: int, zoneName: str | None = None, tags: List[Dict[s
                 8: HVACMode.DRY,
             }
         elif any(childId.startswith("THZONE_") for childId in childrenIds): # Thermostat detected
-            name = "Thermostat (THZONE) "
+            # NOTE: not sure about the name here as we are indeed controlling the Thermostat setting but this in-turn activate underfloor heating.
+            name = "Thermostat "
             if zoneName is not None:
                 modelInfos["name"] = name + "(" + zoneName + ")"
             else:
                 modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
 
             modelInfos["type"] = CozytouchDeviceType.THERMOSTAT
-            modelInfos["currentTemperatureAvailable"] = False
+            modelInfos["currentTemperatureAvailable"] = True
             modelInfos["currentTemperatureAvailableZ1"] = True
+            modelInfos["currentTemperatureAvailableZ2"] = False
+            modelInfos["overrideModeAvailable"] = True
             modelInfos["quietModeAvailable"] = False
 
             modelInfos["HVACModes"] = {
@@ -255,39 +256,39 @@ def get_model_infos(modelId: int, zoneName: str | None = None, tags: List[Dict[s
                 3: HEATING_MODE_ECO_PLUS,
                 4: HEATING_MODE_PROG,
             }
-        # else: # Fallback to AC if none found to keep backward compatibility
-        #     name = "Air Conditioner "
-        #     if zoneName is not None:
-        #         modelInfos["name"] = name + "(" + zoneName + ")"
-        #     else:
-        #         modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
+        else: # Fallback to AC if none found to keep backward compatibility
+            name = "Air Conditioner "
+            if zoneName is not None:
+                modelInfos["name"] = name + "(" + zoneName + ")"
+            else:
+                modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
 
-        #     modelInfos["type"] = CozytouchDeviceType.AC
-        #     modelInfos["currentTemperatureAvailable"] = False
-        #     modelInfos["quietModeAvailable"] = True
+            modelInfos["type"] = CozytouchDeviceType.AC
+            modelInfos["currentTemperatureAvailable"] = False
+            modelInfos["quietModeAvailable"] = True
 
-        #     modelInfos["fanModes"] = {
-        #         1: FAN_LOW,
-        #         2: FAN_MEDIUM,
-        #         3: FAN_HIGH,
-        #         5: FAN_AUTO,
-        #     }
+            modelInfos["fanModes"] = {
+                1: FAN_LOW,
+                2: FAN_MEDIUM,
+                3: FAN_HIGH,
+                5: FAN_AUTO,
+            }
 
-        #     modelInfos["swingModes"] = {
-        #         1: SWING_MODE_UP,
-        #         2: SWING_MODE_MIDDLE_UP,
-        #         3: SWING_MODE_MIDDLE_DOWN,
-        #         4: SWING_MODE_DOWN,
-        #     }
+            modelInfos["swingModes"] = {
+                1: SWING_MODE_UP,
+                2: SWING_MODE_MIDDLE_UP,
+                3: SWING_MODE_MIDDLE_DOWN,
+                4: SWING_MODE_DOWN,
+            }
 
-        #     modelInfos["HVACModes"] = {
-        #         0: HVACMode.OFF,
-        #         1: HVACMode.AUTO,
-        #         3: HVACMode.COOL,
-        #         4: HVACMode.HEAT,
-        #         7: HVACMode.FAN_ONLY,
-        #         8: HVACMode.DRY,
-        #     }
+            modelInfos["HVACModes"] = {
+                0: HVACMode.OFF,
+                1: HVACMode.AUTO,
+                3: HVACMode.COOL,
+                4: HVACMode.HEAT,
+                7: HVACMode.FAN_ONLY,
+                8: HVACMode.DRY,
+            }
 
         if zoneName is not None:
             modelInfos["name"] = name + "(" + zoneName + ")"
@@ -379,7 +380,7 @@ def get_model_infos(modelId: int, zoneName: str | None = None, tags: List[Dict[s
         if zoneName is not None:
             modelInfos["name"] = name + "(" + zoneName + ")"
         else:
-            modelInfos["name"] = name + "(#" + str(modelId - 561) + ")"
+            modelInfos["name"] = name + "(#" + str(modelId - 1504) + ")"
 
         modelInfos["type"] = CozytouchDeviceType.THERMOSTAT
         modelInfos["HVACModes"] = {


### PR DESCRIPTION
This PR adds support for the [Atlantic Thermostat PRE](https://www.atlantic.fr/Piloter-les-appareils/Via-commande-murale/Commande-d-ambiance-murale/Thermostat-Chauffage-au-sol-electrique) used to control [Domocable](https://www.atlantic.fr/Chauffer-le-logement/Chauffage-electrique/Chauffage-au-sol/Plancher-rayonnant-Domocable) / [Soleka](https://www.atlantic.fr/Chauffer-le-logement/Chauffage-electrique/Chauffage-au-sol/Soleka) based electric underfloor heating.

## What changed

This PR adds support for Thermostat Thermal Zone (`TZHONE`) devices as well as update the logic for the detection of available heating/cooling device per `ROOM` entity (`modelID` between 557 and 561).

In order to better detect if an AC or an underfloor heater is available in a `ROOM`, I added logic that checks all the child devices in a room and check their type using their IDs (`UI_1`, `THZONE_1`, ...), favoring ACs first as they are usually reversible then thermal zones and only exposing the support modes. I have also kept the original logic as fallback in case this logic doesn't work with other models. 

To do so, I had to update the `get_model_infos` to also receive the device tags so I can access the `iothubChildrenIds` tag needed for the logic.

These changes should be pretty generic to support other types of underfloor heating system if they expose a `THZONE` device and adding more logic based on different childID prefixes should be pretty straightforward if a new system exposes a new type.

## Usage

This requires all thermostat to be linked to the Atlantic Cozytouch App through the [Cozytouch Hub](https://www.atlantic.fr/Piloter-les-appareils/Via-smartphone/Solutions-connectees/Hub-Cozytouch) and assigned to a room.

Then when adding the Cozytouch integration to Home Assistant, you will see a set of `THZONE` (on per thermostat) and `ROOM` (one per room defined).

<details> 
  <summary>Cozytouch Setup Screen (click to reveal screenshot)</summary>
  <img width="456" height="837" alt="image" src="https://github.com/user-attachments/assets/88f3229f-c60e-4b02-b708-b343eccb5675" />
</details>

The `THZONE` itself will not expose any useful data except connectivity information, so you may not need to add it to HA.

<details> 
  <summary>Cozytouch THZONE details (click to reveal screenshot)</summary>
  <img width="1029" height="359" alt="image" src="https://github.com/user-attachments/assets/4fdfcdee-6a25-4844-b4f2-5f0ac8a5617d" />
</details>

Each `ROOM` will allow you to control the Thermostat directly from HA and expose only the implement heating components.

<details> 
  <summary>Cozytouch ROOM details (click to reveal screenshot)</summary>
  <img width="1016" height="1162" alt="image" src="https://github.com/user-attachments/assets/992466e8-c0e5-4acc-97e1-2d9387f38e8e" />
</details>