### PR TITLE
feat(divali): support Atlantic DIVALI heaters on the new Cozytouch V2…

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -68,6 +68,12 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
             capability.pop("lowestValueCapabilityId")
             capability.pop("highestValueCapabilityId")
             capability["icon"] = "mdi:heat-pump"
+        elif modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            # V2 electric heater / underfloor thermostat (e.g. Atlantic DIVALI,
+            # Atlantic Thermostat PRE). Uses ROOM_CURRENT_HEATING_TARGET_TEMPERATURE
+            # (cap 40) as setpoint, no cooling.
+            capability["name"] = "heat"
+            capability["icon"] = "mdi:thermostat"
         else:
             capability["name"] = "heat"
 
@@ -369,7 +375,11 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["highestValueCapabilityId"] = 161
 
     elif capabilityId == 177:
-        if modelInfos["type"] == CozytouchDeviceType.GAZ_BOILER:
+        if modelInfos["type"] in (
+            CozytouchDeviceType.GAZ_BOILER,
+            CozytouchDeviceType.THERMOSTAT,
+        ):
+            # AC-only setpoint. Heating-only devices don't have a cool target.
             return {}
 
         capability["name"] = "target_cool_temperature"
@@ -623,12 +633,19 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["icon"] = "mdi:fire"
 
     elif capabilityId == 100505:
+        # APK: VENTILATION_CURRENT_POWERFUL_MODE — AC's "boost" mode.
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "powerful_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:wind-power"
 
     elif capabilityId == 100506:
+        # APK: VENTILATION_CURRENT_PRESENCE_DETECTION_MODE.
+        # Enum values: 0=COMFORT (presence detection off), 1=PRESENCE_DETECTION (auto).
+        # Hidden on TOWEL_RACK (upstream choice) but exposed for THERMOSTAT
+        # (electric heaters like the Atlantic DIVALI do support presence detection).
         if modelInfos["type"] == CozytouchDeviceType.TOWEL_RACK:
             capability = {}
         else:
@@ -638,6 +655,11 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
             capability["icon"] = "mdi:account"
 
     elif capabilityId == 100507:
+        # APK: VENTILATION_CURRENT_ENERGY_SAVING_MODE — AC eco switch.
+        # On THERMOSTAT (electric heaters) the eco temperature is expressed via the
+        # PROG_ABSENCE / PROG_NIGHT presets (caps 100196 / 100197), not this switch.
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "eco_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
@@ -714,12 +736,18 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "diag"
 
     elif capabilityId == 100802:
+        # APK: VENTILATION_QUIET_MODE — AC quiet/silent fan setting.
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "quiet_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:fan-minus"
 
     elif capabilityId == 100804:
+        # APK: VENTILATION_SWING_MODE — AC louver swing on/off.
+        if modelInfos["type"] == CozytouchDeviceType.THERMOSTAT:
+            return {}
         capability["name"] = "swing_mode"
         capability["type"] = "switch"
         capability["category"] = "sensor"
@@ -730,6 +758,15 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["type"] = "switch"
         capability["category"] = "sensor"
         capability["icon"] = "mdi:heat-wave"
+
+    elif capabilityId == 104050:
+        # APK: VENTILATION_OPEN_WINDOW_DETECTION. Toggle (0/1) for the heater's
+        # built-in open-window detection (auto-shutoff on a sudden temp drop).
+        # Present on electric heaters in this V2 family (e.g. Atlantic DIVALI).
+        capability["name"] = "open_window_detection"
+        capability["type"] = "switch"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:window-open-variant"
 
     elif capabilityId == 104047:
         # Boost timeout max. in minutes
@@ -754,6 +791,131 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "sensor"
         capability["temperatureMin"] = 15.0
         capability["temperatureMax"] = 65.0
+
+    # ---- Cap names decoded from the Cozytouch Android APK (v3.28.0, 2026-05-28) ----
+    # Class fr.modulotech.app.domain.model.devices.Capabilities. Caps below appear
+    # on V2 electric heaters (e.g. Atlantic DIVALI, Doris, Equateur, Galapagos)
+    # and other devices in the same V2 family. See docs/cozytouch.md for the full
+    # mapping and value-enum semantics.
+
+    elif capabilityId == 218:
+        # WIFI_CONNECTED — enum (0=UNKNOWN, 1=BLINKING, 2=NOT_BLINKING).
+        # NOT a boolean — value "0" means "LED state unknown", not "disconnected".
+        capability["name"] = "wifi_connected"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+        capability["icon"] = "mdi:wifi"
+
+    elif capabilityId == 100013:
+        # THERMOSTAT_MILESTONES_AVAILABLE_TYPES — bitmask of supported milestone
+        # types for the weekly schedule (Mon-Sun caps 100334-100341).
+        capability["name"] = "milestones_available_types"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+        capability["icon"] = "mdi:format-list-bulleted-type"
+
+    elif capabilityId == 100014:
+        # ROOM_TYPE — enum of room categories (bedroom, living, etc.).
+        capability["name"] = "room_type"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+        capability["icon"] = "mdi:home-search"
+
+    elif capabilityId == 100022:
+        # SYSTEM_OPERATING_SERVICE_SUPPORTED_CAPABILITIES — bitmask (companion to
+        # cap 166 which is the "_AVAILABLE_" form).
+        capability["name"] = "service_supported_capabilities"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100023:
+        # SYSTEM_SUPPORTED_MODES_CAPABILITIES — bitmask of supported HVAC modes
+        # (companion to cap 217, which is "_AVAILABLE_").
+        capability["name"] = "modes_supported_capabilities"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100024:
+        # VENTILATION_OPTIONS_AVAILABLE — bitmask:
+        # 1=TEMPERATURE, 2=OPEN_WINDOW_DETECTION, 4=PRESENCE_DETECTION, 32=ADAPTIVE_PLANNING.
+        capability["name"] = "options_available"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100196:
+        # PROG_ABSENCE — setpoint for the "Absence" lifestyle preset, used by the
+        # weekly schedule (state value 2 = UNOCCUPIED). Format: "[temp, mode]".
+        capability["name"] = "prog_absence_setpoint"
+        capability["type"] = "string"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:home-export-outline"
+
+    elif capabilityId == 100197:
+        # PROG_NIGHT — setpoint for the "Night" lifestyle preset (schedule state
+        # value 3 = FORCED_OCCUPIED). Format: "[temp, mode]".
+        capability["name"] = "prog_night_setpoint"
+        capability["type"] = "string"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:weather-night"
+
+    elif capabilityId == 100198:
+        # PROG_PRESENCE — setpoint for the "Presence" lifestyle preset (schedule
+        # state value 1 = OCCUPIED). Format: "[temp, mode]".
+        capability["name"] = "prog_presence_setpoint"
+        capability["type"] = "string"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:home-account"
+
+    elif capabilityId == 100334:
+        # THERMOSTAT_LIFESTYLE_HEATING_MONDAY — array of [minutesSinceMidnight,
+        # LifestyleMilestoneState] where state: 1=OCCUPIED (→ uses PROG_PRESENCE),
+        # 2=UNOCCUPIED (→ PROG_ABSENCE), 3=FORCED_OCCUPIED (→ PROG_NIGHT).
+        capability["name"] = "lifestyle_schedule_monday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100335:
+        capability["name"] = "lifestyle_schedule_tuesday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100336:
+        capability["name"] = "lifestyle_schedule_wednesday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100337:
+        capability["name"] = "lifestyle_schedule_thursday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100338:
+        capability["name"] = "lifestyle_schedule_friday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100339:
+        capability["name"] = "lifestyle_schedule_saturday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    # Note: capability 100340 is deliberately skipped — Atlantic doesn't use it
+    # on this device class. Sunday is on 100341.
+
+    elif capabilityId == 100341:
+        capability["name"] = "lifestyle_schedule_sunday"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+
+    elif capabilityId == 100503:
+        # WIFI_SOFTWARE_VERSION — companion firmware string on the HUB
+        # (the per-device "interface_fw" is cap 316).
+        capability["name"] = "wifi_software_version"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+        capability["icon"] = "mdi:tag"
+
+    # ---- end APK-decoded additions ----
 
     # For test
     elif capabilityId == 312:

--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -226,7 +226,9 @@ class Hub(DataUpdateCoordinator):
                     "modelId": remote_device["modelId"],
                     "productId": remote_device["productId"],
                     "zoneId": remote_device["zoneId"],
-                    "modelInfos": get_model_infos(remote_device["modelId"]),
+                    "modelInfos": get_model_infos(
+                        remote_device["modelId"], remote_device.get("tags", [])
+                    ),
                     "capabilities": [],
                     "tags": [],
                 }
@@ -350,9 +352,11 @@ class Hub(DataUpdateCoordinator):
                                 zoneId = masterDev["zoneId"]
                                 break
 
-                return get_model_infos(dev["modelId"], self.get_zone_name(zoneId))
+                return get_model_infos(
+                    dev["modelId"], dev.get("tags", []), self.get_zone_name(zoneId)
+                )
 
-        return get_model_infos(-1)
+        return get_model_infos(-1, [])
 
     def get_serial_number(self, deviceId: int | None = None) -> str:
         """Get serial number."""
@@ -374,7 +378,7 @@ class Hub(DataUpdateCoordinator):
         capabilities = []
         for dev in self._devices:
             if dev["deviceId"] == deviceId:
-                modelInfos = get_model_infos(dev["modelId"])
+                modelInfos = get_model_infos(dev["modelId"], dev.get("tags", []))
                 for capability in dev["capabilities"]:
                     capability_infos = get_capability_infos(
                         modelInfos,

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -15,6 +15,12 @@ Optional :
     * swingModes : list of value/mode pairs
     * quietModeAvailable : enable quiet mode availability (default : False)
 
+Note on modelIds 557-561 :
+    These Cozytouch V2 ROOM modelIds are reused across device classes — they
+    can represent either an Air Conditioner (with `UI_*` child devices) or an
+    electric heater / underfloor thermostat (with `THZONE_*` child devices).
+    The integration discriminates via the `iothubChildrenIds` tag on the ROOM
+    device (passed in via the `tags` parameter). Approach taken from PR #116.
 """  # noqa: D205
 
 from enum import StrEnum
@@ -54,8 +60,34 @@ class CozytouchDeviceType(StrEnum):
     HUB = "hub"
 
 
-def get_model_infos(modelId: int, zoneName: str | None = None):
-    """Return infos from model ID."""
+def _get_iothub_children_ids(tags: list | None) -> list[str]:
+    """Extract child device names from the `iothubChildrenIds` device tag (V2 setups).
+
+    Returns an empty list when the tag is absent — callers should treat that as
+    "no children declared", not as an error.
+    """
+    if not tags:
+        return []
+    for tag in tags:
+        if isinstance(tag, dict) and tag.get("label") == "iothubChildrenIds":
+            value = tag.get("value") or ""
+            return [c for c in value.split(",") if c]
+    return []
+
+
+def get_model_infos(
+    modelId: int,
+    tags: list | None = None,
+    zoneName: str | None = None,
+):
+    """Return infos from model ID.
+
+    `tags` is the device's tag list from the Cozytouch API (each entry a
+    `{label, value}` dict). When provided, modelIds in the 557-561 range are
+    discriminated between Air Conditioner (UI_* children) and Thermostat
+    (THZONE_* children, used by underfloor heating and electric room heaters
+    like the Atlantic DIVALI Neo H).
+    """
     modelInfos = {"modelId": modelId, "HVACModesCapabilityId": {7, 8}}
 
     if modelId == 56:
@@ -185,39 +217,63 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
             0: HVACMode.OFF,
         }
 
+    elif modelId == 1457:
+        # New Cozytouch HUB (replaces Naviclim, supports more zones, used with
+        # Zigbee-connected Atlantic DIVALI heaters and other V2 devices).
+        modelInfos["name"] = "HUB Cozytouch"
+        modelInfos["type"] = CozytouchDeviceType.HUB
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
+        }
+
     elif modelId >= 557 and modelId <= 561:
-        name = "Air Conditioner "
+        # ROOM device in the Cozytouch V2 protocol. The same modelId range is
+        # reused for ACs (with UI_* children) and electric-heater / underfloor
+        # thermostats (with THZONE_* children). Discriminate via iothubChildrenIds.
+        childrenIds = _get_iothub_children_ids(tags)
+        is_thermostat = any(c.startswith("THZONE_") for c in childrenIds)
+
+        if is_thermostat:
+            # Electric heater / underfloor thermostat — heat only, no fan/swing/cool.
+            name = "Thermostat "
+            modelInfos["type"] = CozytouchDeviceType.THERMOSTAT
+            modelInfos["currentTemperatureAvailable"] = True
+            modelInfos["overrideModeAvailable"] = True
+            modelInfos["HVACModes"] = {
+                0: HVACMode.OFF,
+                4: HVACMode.HEAT,
+            }
+        else:
+            # Default behaviour: AC (preserves backward compat for Naviclim setups).
+            name = "Air Conditioner "
+            modelInfos["type"] = CozytouchDeviceType.AC
+            modelInfos["currentTemperatureAvailable"] = False
+            modelInfos["quietModeAvailable"] = True
+            modelInfos["fanModes"] = {
+                1: FAN_LOW,
+                2: FAN_MEDIUM,
+                3: FAN_HIGH,
+                5: FAN_AUTO,
+            }
+            modelInfos["swingModes"] = {
+                1: SWING_MODE_UP,
+                2: SWING_MODE_MIDDLE_UP,
+                3: SWING_MODE_MIDDLE_DOWN,
+                4: SWING_MODE_DOWN,
+            }
+            modelInfos["HVACModes"] = {
+                0: HVACMode.OFF,
+                1: HVACMode.AUTO,
+                3: HVACMode.COOL,
+                4: HVACMode.HEAT,
+                7: HVACMode.FAN_ONLY,
+                8: HVACMode.DRY,
+            }
+
         if zoneName is not None:
             modelInfos["name"] = name + "(" + zoneName + ")"
         else:
             modelInfos["name"] = name + "(#" + str(modelId - 556) + ")"
-
-        modelInfos["type"] = CozytouchDeviceType.AC
-        modelInfos["currentTemperatureAvailable"] = False
-        modelInfos["quietModeAvailable"] = True
-
-        modelInfos["fanModes"] = {
-            1: FAN_LOW,
-            2: FAN_MEDIUM,
-            3: FAN_HIGH,
-            5: FAN_AUTO,
-        }
-
-        modelInfos["swingModes"] = {
-            1: SWING_MODE_UP,
-            2: SWING_MODE_MIDDLE_UP,
-            3: SWING_MODE_MIDDLE_DOWN,
-            4: SWING_MODE_DOWN,
-        }
-
-        modelInfos["HVACModes"] = {
-            0: HVACMode.OFF,
-            1: HVACMode.AUTO,
-            3: HVACMode.COOL,
-            4: HVACMode.HEAT,
-            7: HVACMode.FAN_ONLY,
-            8: HVACMode.DRY,
-        }
 
     elif modelId >= 562 and modelId <= 570:
         name = "Air Conditioner User Interface "


### PR DESCRIPTION
… HUB

DIVALI is an Atlantic V2 electric room heater on Zigbee, exposed via the new Cozytouch HUB (modelId 1457). It shares its API surface with the rest of Atlantic's V2 electric heater family (Doris, Equateur, Galapagos, Asama, Kelud, Gyali, IPALA) — so this patch helps them all.

Approach (informed by PR #116 + reverse-engineering the Cozytouch Android APK v3.28.0, class fr.modulotech.app.domain.model.devices.Capabilities):

* model.py
  - Add modelId 1457 → HUB (the new Cozytouch HUB that replaces Naviclim).
  - get_model_infos(modelId, tags=None, zoneName=None) — accept the device's tag list. tags is optional for backward compat.
  - 557-561 range: inspect iothubChildrenIds tag. THZONE_* children → map to THERMOSTAT type with heat-only HVAC modes (DIVALI, underfloor heating, etc.). UI_* children or no tag → preserve existing AC behaviour.

* capability.py
  - Cap 1/2/7/8 climate: add THERMOSTAT branch with mdi:thermostat icon.
  - Gate AC-noise caps for THERMOSTAT (177 cool target, 100505 powerful, 100507 eco_mode switch, 100802 quiet, 100804 swing) — return {} so the AC-artefact entities don't pollute the device.
  - Cap 100506 (presence_mode) stays visible on THERMOSTAT — electric heaters in this family genuinely have presence detection (PresenceDetectionMode enum: 0=COMFORT, 1=PRESENCE_DETECTION).
  - Add cap 104050 = VENTILATION_OPEN_WINDOW_DETECTION as a switch entity.
  - Add the APK-named diag/sensor caps observed on DIVALI / sibling devices: 218 (WIFI_CONNECTED, enum not bool), 100013 (THERMOSTAT_MILESTONES_AVAILABLE_TYPES bitmask), 100014 (ROOM_TYPE), 100022/100023/100024 (supported/available bitmasks), 100196/100197/100198 (PROG_ABSENCE/NIGHT/PRESENCE setpoints, [temp,mode]), 100334-100341 (THERMOSTAT_LIFESTYLE_HEATING_MON..SUN; 100340 is skipped), 100503 (WIFI_SOFTWARE_VERSION on HUB).

* hub.py
  - Plumb device tags through to get_model_infos at the three call sites.

No new CozytouchDeviceType enum value is added: Atlantic's own V2 data model uses one generic AirConditionerRoom class for both ACs and electric heaters, discriminated by supported HVAC modes (cap 217). Reusing THERMOSTAT matches that model and PR #116's design.

Tested locally against an Atlantic DIVALI Neo H 1250W BLC (modelId 557/558 ROOM + 1505/1506 THZONE) on a new Cozytouch HUB (modelId 1457).