### PR TITLE
fix: ignore devices using overkiz api

### DIFF
--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -224,6 +224,9 @@ class Hub(DataUpdateCoordinator):
         # Create new devices
         deviceIndex = -1
         for remote_device in json_data[0]["devices"]:
+            if remote_device.get("deviceUrl", "").startswith("io://"):
+                continue
+
             deviceIndex = -1
             for i, local_device in enumerate(self._devices):
                 if remote_device["deviceId"] == local_device["deviceId"]:


### PR DESCRIPTION
When authenticating with this custom integration, I get an "unknown error". 

After investigation, auth is ok but the integration is failing on `get_model_infos` because modelId of 6 devices have a null value instead of an expected int. These 6 devices are my devices connected with Cozytouch hub using IO-homecontrol protocol. Even if they are not supported by the API used by Wifi devices, they are still listed.

As they are supported by Overkiz integration, I fixed the issue by ignoring these devices to be created by this integration. If the device id is starting with `io://`, this means the device is connected to Cozytouch hub using IO-homecontrol.

This could also fix https://github.com/gduteil/cozytouch/issues/80 and https://github.com/gduteil/cozytouch/issues/120.

Btw, thanks for your work on this custom integration! :)