### PR TITLE
Fix numeric sensors treating 0 as missing and parse errors as 0.0

### DIFF
--- a/custom_components/cozytouch/sensor.py
+++ b/custom_components/cozytouch/sensor.py
@@ -591,11 +591,11 @@ class CozytouchUnitSensor(CozytouchSensor):
     @property
     def native_value(self) -> float | None:
         """Value of the sensor."""
-        if self._last_value:
+        if self._last_value is not None:
             try:
                 return float(self._last_value)
-            except ValueError:
-                return 0.0
+            except (TypeError, ValueError):
+                return None
 
 
 class CozytouchTimeSensor(CozytouchSensor):


### PR DESCRIPTION
## Summary
`CozytouchUnitSensor.native_value` used `if self._last_value:` — a capability value of `"0"`/`0` is falsy, so a genuine zero reading (e.g. 0% hot water available) fell through and the sensor showed no value. Unparseable values returned a fake `0.0`, indistinguishable from a real zero — this is the same misleading-0.0 pattern discussed during the capability outage in #129, where dropped temperature capabilities read as `0.0 °C` instead of unknown.

- `if self._last_value:` → `if self._last_value is not None:`
- `except ValueError: return 0.0` → `except (TypeError, ValueError): return None` so HA shows *unknown* instead of a lying zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01635y2ipTY7KdjuMDvqbDtH