### PR TITLE
Add model mapping for Atlantic Egeo VS 250L (modelId 2346)

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -102,6 +102,16 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["lowestValueCapabilityId"] = 160
         capability["highestValueCapabilityId"] = 161
 
+        if modelId == 2346:
+            # Egeo VS 250L does not report capabilities 160/161, so number.py
+            # keeps its 0 / 60.0 / 0.5 defaults. Since _handle_coordinator_update
+            # clamps the value it reads as well as the one it writes, a tank set
+            # to 65 C in the Cozytouch app was displayed as 60.0 in HA. These are
+            # the bounds the app offers for this model.
+            capability["lowest_value"] = 50
+            capability["highest_value"] = 65
+            capability["step"] = 1
+
     elif capabilityId == 25:
         capability["name"] = "number_of_starts_ch_pump"
         capability["type"] = "int"

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -456,6 +456,20 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
             0: HEATING_MODE_MANUAL,
             3: HEATING_MODE_ECO_PLUS,
         }
+
+    elif modelId == 2346:
+        modelInfos["name"] = "Egeo VS 250L"
+        modelInfos["type"] = CozytouchDeviceType.WATER_HEATER
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
+            4: HVACMode.HEAT,
+        }
+
+        modelInfos["HeatingModes"] = {
+            0: HEATING_MODE_MANUAL,
+            3: HEATING_MODE_ECO_PLUS,
+            4: HEATING_MODE_PROG,
+        }
     else:
         modelInfos["name"] = "Unknown product (" + str(modelId) + ")"
         modelInfos["type"] = CozytouchDeviceType.UNKNOWN


### PR DESCRIPTION
## Problem

`modelId 2346` (Atlantic Egeo VS 250L water heater) has no entry in `get_model_infos()`, so devices of this model fall through to the default `UNKNOWN` branch. Since that branch sets no `HeatingModes`, `select.*_mode_chauffe` (capability 87) is permanently stuck reporting `Undefined` instead of the real heating mode.

## Fix

Add a `modelId == 2346` branch mirroring the standard water-heater pattern already used by several other models in this file (236, 389, 390, 1369, 1376, 1371, 1372, 1657, 1966): `type = WATER_HEATER`, `HVACModes = {0: OFF, 4: HEAT}`, `HeatingModes = {0: manual, 3: eco_plus, 4: prog}`.

## Verification

Confirmed against a live device dump (Cozytouch API `dump_json` debug option) for a real Egeo VS 250L: capability 87 currently reports raw value `"3"`, which is a valid state under the standard enum (`eco_plus`) — consistent with reusing the existing mapping rather than needing a new one. Boost is a separate capability (165, exposed as a switch), not part of this enum, so it's untouched by this change.

After applying the fix locally and restarting Home Assistant, `select.unknown_product_2346_mode_chauffe` correctly reports the device's actual heating mode instead of `Undefined`.