### PR TITLE
Fix entity names falling back to the device name

### DIFF
--- a/custom_components/cozytouch/sensor.py
+++ b/custom_components/cozytouch/sensor.py
@@ -303,7 +303,11 @@ class CozytouchSensor(SensorEntity, CoordinatorEntity):
         self._config_uniq_id = config_uniq_id
         self._last_value: str | None = None
         self._device_uniq_id = config_uniq_id
-        self._attr_name = name
+
+        # Do not set self._attr_name here. Leaving _attr_name as UNDEFINED lets
+        # Home Assistant resolve the entity name from translation_key. Assigning
+        # it (to None for unnamed sensors) would force the device name on every
+        # entity and drop the translated capability names.
 
         if value_type:
             self._value_type = value_type
@@ -384,7 +388,7 @@ class CozytouchSensor(SensorEntity, CoordinatorEntity):
         """Update the value of the sensor from the hub."""
         # Get last seen value from controller
         value = self.get_value()
-        # _LOGGER.info("%s: update %s (%s)", self._config_title, self._attr_name, value)
+        # _LOGGER.info("%s: update %s (%s)", self._config_title, self.name, value)
 
         # Handle entity availability
         if value is None:
@@ -393,14 +397,14 @@ class CozytouchSensor(SensorEntity, CoordinatorEntity):
                     _LOGGER.debug(
                         "%s: marking the %s sensor as unavailable: Cozytouch connection lost",
                         self._config_title,
-                        self._attr_name,
+                        self.name,
                     )
                     self._attr_available = False
         elif not self._attr_available:
             _LOGGER.info(
                 "%s: marking the %s sensor as available now !",
                 self._config_title,
-                self._attr_name,
+                self.name,
             )
             self._attr_available = True
 


### PR DESCRIPTION
Fixes #150

### Problem
With `_attr_has_entity_name = True`, Home Assistant resolves an entity's
name via `translation_key` only when `_attr_name` is **undefined**. The
`Entity.name` property checks `hasattr(self, "_attr_name")` first, so any
value — including `None` — short-circuits translation, and a `None` name
makes HA display the device name. `CozytouchSensor.__init__` set
`self._attr_name = name` (usually `None`), causing every unnamed sensor to
show the device name.

The `self._attr_name = name` line was introduced by commit 7f9db28 (part
of #121, whose main purpose is timeout/error handling). It was added to
avoid an `AttributeError`, since logging calls in
`_handle_coordinator_update` read `self._attr_name`.

### Changes
- Stop setting `self._attr_name`, leaving it undefined so naming goes
  through `translation_key` (with `entity_description.name` as fallback).
- Route the availability log messages through the public `self.name`
  property instead of the now-undefined `self._attr_name`, keeping the
  logs working without the crash.
- Update the commented-out update log the same way, so re-enabling it
  cannot reintroduce the `AttributeError`.

### Testing
- Entities display their translated capability names again.
- Availability transitions (connection lost / restored) log correctly with
  no `AttributeError`.
