### PR TITLE
Add support for ACI HYB hybrid water heaters (PHAZY / AQUEO / DURALIS)

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -464,6 +464,12 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["type"] = "prog"
         capability["category"] = "diag"
 
+    elif capabilityId == 218:
+        capability["name"] = "wifi_connected"
+        capability["type"] = "binary"
+        capability["category"] = "diag"
+        capability["icon"] = "mdi:wifi"
+
     elif capabilityId == 219:
         capability["name"] = "wifi_ssid"
         capability["type"] = "string"
@@ -538,6 +544,16 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["type"] = "progtime"
         capability["category"] = "diag"
 
+    elif capabilityId == 252:
+        capability["name"] = "target_temperature_max"
+        capability["type"] = "temperature"
+        capability["category"] = "diag"
+
+    elif capabilityId == 253:
+        capability["name"] = "target_temperature_min"
+        capability["type"] = "temperature"
+        capability["category"] = "diag"
+
     elif capabilityId == 258:
         capability["name"] = "tank_capacity"
         capability["type"] = "volume"
@@ -585,6 +601,24 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["name"] = "hot_water_available"
         capability["type"] = "percentage"
         capability["category"] = "sensor"
+
+    elif capabilityId == 280:
+        capability["name"] = "cold_water_temperature"
+        capability["type"] = "temperature"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:coolant-temperature"
+
+    elif capabilityId == 292:
+        capability["name"] = "hot_water_level_requested"
+        capability["type"] = "int"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:water-plus"
+
+    elif capabilityId == 293:
+        capability["name"] = "current_hot_water_level"
+        capability["type"] = "int"
+        capability["category"] = "sensor"
+        capability["icon"] = "mdi:water-check"
 
     elif capabilityId == 283:
         capability["name"] = "off_peak_hours"
@@ -741,6 +775,16 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["highest_value"] = 60
         capability["step"] = 5
 
+    elif capabilityId == 105300:
+        capability["name"] = "water_temperature_limit"
+        capability["type"] = "temperature"
+        capability["category"] = "diag"
+
+    elif capabilityId == 105304:
+        capability["name"] = "max_target_temperature_derogation"
+        capability["type"] = "temperature"
+        capability["category"] = "diag"
+
     elif capabilityId == 105906:
         capability["name"] = "Target 105906"
         capability["type"] = "temperature_percent_adjustment_number"
@@ -760,6 +804,11 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["name"] = "Temp_" + str(capabilityId)
         capability["type"] = "temperature_adjustment_number"
         capability["category"] = "sensor"
+
+    elif capabilityId == 228:
+        capability["name"] = "absence_dhw_temperature"
+        capability["type"] = "temperature"
+        capability["category"] = "diag"
 
     else:
         return None

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -139,21 +139,20 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
             4: HEATING_MODE_PROG,
         }
 
-    elif modelId == 389:
-        modelInfos["name"] = "AQUEO ACI HYB VS 300L 3000M"
-        modelInfos["type"] = CozytouchDeviceType.WATER_HEATER
-        modelInfos["HVACModes"] = {
-            0: HVACMode.OFF,
-            4: HVACMode.HEAT,
-        }
-        modelInfos["HeatingModes"] = {
-            0: HEATING_MODE_MANUAL,
-            3: HEATING_MODE_ECO_PLUS,
-            4: HEATING_MODE_PROG,
-        }
-
-    elif modelId == 390:
-        modelInfos["name"] = "AQUEO ACI HYB VM 150L 2200M"
+    elif modelId in (386, 387, 388, 389, 390, 391, 392, 393, 394):
+        # ACI HYB hybrid water heaters, sold under the PHAZY / AQUEO / DURALIS
+        # brands in VS 300L, VM 150L and VM 200L variants (same platform).
+        modelInfos["name"] = {
+            386: "PHAZY VS 300L 3000M",
+            387: "PHAZY VM 150L 2200M",
+            388: "PHAZY VM 200L 2200M",
+            389: "AQUEO ACI HYB VS 300L 3000M",
+            390: "AQUEO ACI HYB VM 150L 2200M",
+            391: "AQUEO ACI HYB VM 200L 2200M",
+            392: "DURALIS CONNECT ACI HYB VS 300L 3000M",
+            393: "DURALIS CONNECT ACI HYB VM 150L 2200M",
+            394: "DURALIS CONNECT ACI HYB VM 200L 2200M",
+        }[modelId]
         modelInfos["type"] = CozytouchDeviceType.WATER_HEATER
         modelInfos["HVACModes"] = {
             0: HVACMode.OFF,

--- a/custom_components/cozytouch/translations/en.json
+++ b/custom_components/cozytouch/translations/en.json
@@ -164,6 +164,15 @@
             }
         },
         "sensor": {
+            "wifi_connected":           { "name": "Wifi Connected" },
+            "target_temperature_max":   { "name": "Target Temperature Max" },
+            "target_temperature_min":   { "name": "Target Temperature Min" },
+            "cold_water_temperature":   { "name": "Cold Water Temperature" },
+            "hot_water_level_requested": { "name": "Hot Water Level Requested" },
+            "current_hot_water_level":  { "name": "Current Hot Water Level" },
+            "water_temperature_limit":  { "name": "Water Temperature Limit" },
+            "max_target_temperature_derogation": { "name": "Max Target Temperature Derogation" },
+            "absence_dhw_temperature":  { "name": "Absence DHW Temperature" },
             "air_conditioner":          { "name": "Air Conditioner" },
             "away_mode":                { "name": "Away Mode" },
             "away_mode_start":          { "name": "Away Mode Start" },

--- a/custom_components/cozytouch/translations/fr.json
+++ b/custom_components/cozytouch/translations/fr.json
@@ -164,6 +164,15 @@
             }
         },
         "sensor": {
+            "wifi_connected":           { "name": "Wifi connecté" },
+            "target_temperature_max":   { "name": "Consigne max" },
+            "target_temperature_min":   { "name": "Consigne min" },
+            "cold_water_temperature":   { "name": "Température eau froide" },
+            "hot_water_level_requested": { "name": "Niveau d'eau chaude demandé" },
+            "current_hot_water_level":  { "name": "Niveau d'eau chaude actuel" },
+            "water_temperature_limit":  { "name": "Limite température eau" },
+            "max_target_temperature_derogation": { "name": "Consigne max dérogation" },
+            "absence_dhw_temperature":  { "name": "Température absence ECS" },
             "air_conditioner":          { "name": "Climatisation" },
             "away_mode":                { "name": "Absence" },
             "away_mode_start":          { "name": "Absence Début" },


### PR DESCRIPTION
Fixes #154
Fixes #135

### What
Adds support for the nine ACI HYB hybrid water heaters that share the same
platform (`productId 7`), sold under three brands in three formats. They only
differ by their commercial name, so they are handled by a single consolidated
`WATER_HEATER` block whose name comes from a per-`modelId` table.

| Format         | PHAZY | AQUEO | DURALIS |
|----------------|-------|-------|---------|
| VS 300L 3000M  | 386   | 389*  | 392     |
| VM 150L 2200M  | 387   | 390*  | 393     |
| VM 200L 2200M  | 388   | 391   | 394     |

\* 389 and 390 already existed and are merged into the new block (no behavior
change for them). Names match the Atlantic product catalog
(`/magellan/productmodels/models/{id}`).

### Capabilities
Maps nine capabilities these devices expose, using the semantic names found in
the official Cozytouch app (diagnostic unless noted):
`218 wifi_connected`, `252/253 target_temperature_max/min`,
`280 cold_water_temperature` (sensor), `292/293 hot_water_level
requested/current` (sensor), `105300 water_temperature_limit`,
`105304 max_target_temperature_derogation`, `228 absence_dhw_temperature`.
Adds the matching English and French translation keys.

### Testing
Validated on a real DURALIS 394 (VM 200L): the device is now recognized
(model shows "DURALIS CONNECT ACI HYB VM 200L 2200M" instead of "Unknown
product (394)"), the heating mode selector works, and the mapped sensors
appear with proper names.

### Notes
- Refs #73 and #107 (Aqueo 200L = modelId 391): this adds the missing model.
  The `water_consumption` capability (269) reads `null` device-side, so the
  "unknown consumption" they mention is not addressable by the mapping here.
