### PR TITLE
Surface poll failures to HA and stop leaking aiohttp sessions

### DIFF
--- a/custom_components/cozytouch/__init__.py
+++ b/custom_components/cozytouch/__init__.py
@@ -44,14 +44,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await theHub.connect()
     if not theHub.online:
+        # HA discards this hub and builds a new one on each retry, so release the
+        # aiohttp session here or every attempt leaks one
+        await theHub.close()
         # tells HA to retry setup with exponential backoff until the network is available
         raise ConfigEntryNotReady("Cannot connect to Atlantic Cozytouch API")
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = theHub
 
     theHub.set_create_entities_for_unknown_entities(entry.data["create_unknown"])
-    await theHub.async_config_entry_first_refresh()
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    try:
+        # raises ConfigEntryNotReady if the first poll fails, which also gets us
+        # a retry -- but only if we hand the session back first
+        await theHub.async_config_entry_first_refresh()
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except Exception:
+        # HA does not call async_unload_entry when setup fails, so clean up here
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        await theHub.close()
+        raise
 
     return True
 
@@ -60,6 +71,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        theHub = hass.data[DOMAIN].pop(entry.entry_id)
+        # a reload builds a brand new hub, so the old session has to go with it
+        await theHub.close()
 
     return unload_ok

--- a/custom_components/cozytouch/config_flow.py
+++ b/custom_components/cozytouch/config_flow.py
@@ -27,6 +27,8 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     hub = Hub(hass, data["username"], data["password"])
     result = await hub.test_connection()
     if not result:
+        # the caller only closes the hub it gets back, so close it on the way out
+        await hub.close()
         raise CannotConnect
 
     return hub

--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -13,7 +13,7 @@ from aiohttp import ClientError, ClientSession, ClientTimeout, ContentTypeError,
 from homeassistant import exceptions
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .capability import get_capability_infos
@@ -148,6 +148,15 @@ class Hub(DataUpdateCoordinator):
                     timeout=REQUEST_TIMEOUT,
                 ) as response:
                     json_data = await response.json()
+
+                    # An empty list or an error dict would blow up on json_data[0]
+                    # below; treat it as a failed connection so setup is retried
+                    if not isinstance(json_data, list) or not json_data:
+                        _LOGGER.warning(
+                            "connect: unexpected setup payload (%s)",
+                            type(json_data).__name__,
+                        )
+                        raise CannotConnect
 
                     # Store setup
                     for key in (
@@ -292,24 +301,24 @@ class Hub(DataUpdateCoordinator):
                 ) as response:
                     # 401 means the token was rejected; force re-auth next poll
                     if response.status == 401:
-                        _LOGGER.warning("Got 401, forcing re-authentication next poll")
                         self.online = False
-                        return
+                        raise UpdateFailed(
+                            "Token rejected (401), forcing re-authentication next poll"
+                        )
 
                     if response.status != 200:
-                        _LOGGER.warning(
-                            "Unexpected status %d from capabilities endpoint",
-                            response.status,
-                        )
                         self.online = False
-                        return
+                        raise UpdateFailed(
+                            f"Unexpected status {response.status} from capabilities endpoint"
+                        )
 
                     try:
                         json_data = await response.json()
-                    except ContentTypeError:
-                        _LOGGER.warning("Non-JSON response from capabilities endpoint")
+                    except ContentTypeError as err:
                         self.online = False
-                        return
+                        raise UpdateFailed(
+                            "Non-JSON response from capabilities endpoint"
+                        ) from err
 
                     if isinstance(json_data, list):
                         for dev in self._devices:
@@ -333,28 +342,26 @@ class Hub(DataUpdateCoordinator):
                                     self._timestamp_away_mode_end,
                                 )
                     else:
-                        _LOGGER.warning(
-                            "Capabilities response is not a list (got %s), forcing reconnect",
-                            type(json_data).__name__,
-                        )
                         self.online = False
+                        raise UpdateFailed(
+                            f"Capabilities response is not a list (got {type(json_data).__name__}), forcing reconnect"
+                        )
 
-            except asyncio.TimeoutError:
-                _LOGGER.warning(
-                    "Timeout fetching capabilities for device %d, forcing reconnect",
-                    self._deviceId,
-                )
+            except asyncio.TimeoutError as err:
                 self.online = False
+                raise UpdateFailed(
+                    f"Timeout fetching capabilities for device {self._deviceId}, forcing reconnect"
+                ) from err
             except ClientError as err:
-                _LOGGER.warning(
-                    "Network error fetching capabilities for device %d: %s, forcing reconnect",
-                    self._deviceId,
-                    err,
-                )
                 self.online = False
+                raise UpdateFailed(
+                    f"Network error fetching capabilities for device {self._deviceId}: {err}, forcing reconnect"
+                ) from err
 
         else:
             await self.connect()
+            if not self.online:
+                raise UpdateFailed("Cannot connect to Atlantic Cozytouch API")
 
     def devices(self):
         """Get devices list."""


### PR DESCRIPTION
Three related issues around error handling during setup and polling.

### 1. `_async_update_data` swallowed every failure

Each failure path (401, unexpected status, non-JSON body, non-list payload, timeout, `ClientError`) set `self.online = False` and returned. From the coordinator's point of view that is a *successful* update that produced no data, so:

- entities kept serving stale values with no indication anything was wrong
- `async_config_entry_first_refresh()` could never raise `ConfigEntryNotReady`, so a failure during initial setup was not retried

These now raise `UpdateFailed`, which is the `DataUpdateCoordinator` contract. `self.online = False` is kept everywhere so the next poll still re-authenticates. The matching `_LOGGER.warning` calls are removed because the coordinator already logs the `UpdateFailed` message (once, then debounced) — they were duplicating output.

**Behaviour change worth noting:** entities now go `unavailable` on a transient network error instead of holding their last value. That is the standard behaviour for cloud-polling integrations, but it is visible in the UI and in history graphs, so flagging it explicitly.

### 2. `connect()` indexed `json_data[0]` unguarded

If `setupviewv2` returns an empty list or an error dict, the `IndexError` escapes the `try` (which only catches `CannotConnect`, `ClientError` and `asyncio.TimeoutError`) and pins the config entry to `setup_error`, with no automatic retry. An unexpected payload is now treated as `CannotConnect` so it goes through the normal retry path.

### 3. Leaked `ClientSession` on every failed setup attempt

Each `Hub` owns a `ClientSession`, and HA does **not** call `async_unload_entry` when setup fails — it simply builds a fresh `Hub` on the next attempt. So every `ConfigEntryNotReady` retry leaked a session, producing a stream of `Unclosed client session` warnings during an outage. The hub is now closed on four paths:

- the `ConfigEntryNotReady` bail-out in `async_setup_entry`
- first-refresh / `async_forward_entry_setups` failure (wrapped so `hass.data` is cleaned up too)
- `async_unload_entry`, so a reload does not leak the previous session
- `config_flow.validate_input`, which raised `CannotConnect` without closing the hub it had just created — one leak per failed login attempt in the UI

Making `first_refresh` able to raise is what turned the second path into a leak, so it is fixed here rather than separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)