### PR TITLE
Give entities their own names instead of the device name

### DIFF
--- a/custom_components/cozytouch/sensor.py
+++ b/custom_components/cozytouch/sensor.py
@@ -303,7 +303,12 @@ class CozytouchSensor(SensorEntity, CoordinatorEntity):
         self._config_uniq_id = config_uniq_id
         self._last_value: str | None = None
         self._device_uniq_id = config_uniq_id
-        self._attr_name = name
+
+        # Only set _attr_name when there is a name to set. Assigning None here
+        # would tell HA this entity *is* the device, which collapses every
+        # entity to the device name and skips the translation key entirely.
+        if name:
+            self._attr_name = name
 
         if value_type:
             self._value_type = value_type
@@ -393,14 +398,14 @@ class CozytouchSensor(SensorEntity, CoordinatorEntity):
                     _LOGGER.debug(
                         "%s: marking the %s sensor as unavailable: Cozytouch connection lost",
                         self._config_title,
-                        self._attr_name,
+                        self.name,
                     )
                     self._attr_available = False
         elif not self._attr_available:
             _LOGGER.info(
                 "%s: marking the %s sensor as available now !",
                 self._config_title,
-                self._attr_name,
+                self.name,
             )
             self._attr_available = True
 


### PR DESCRIPTION
Every entity on a device renders with the bare device name. On my install all 27 entities on an air conditioner read `Clim chambre parents`, in both the Controls and the Sensors card, which makes them impossible to tell apart.

### Cause

`CozytouchSensor` is the base class for every platform — climate, switch, number, select, time, datetime and sensor — and it assigns:

```python
self._attr_name = name          # name is None for most callers
```

With `_attr_has_entity_name = True`, an explicit name of `None` has a specific meaning in HA: the entity *represents the device itself*. HA then shows the bare device name and never consults `translation_key`.

The subtle part is that `hasattr(self, "_attr_name")` becomes true as soon as the attribute is assigned, even to `None`. Not assigning it is a different state from assigning `None`, and only the former lets the translation lookup run.

### The translations were already there

`translations/en.json` has 103 `sensor` keys. I checked every capability name my devices produce — all 27 have an entry. They were simply never reached.

Setting `_attr_name` only when a name is actually given fixes it. Before and after on the same device:

```
before                     after
Clim chambre parents       Climatisation
Clim chambre parents       Durée Délégation Restante Z1
Clim chambre parents       Flamme
Clim chambre parents       Mode Eco
Clim chambre parents       Mode Prog
Clim chambre parents       Température Thermostat Z1
```

### One knock-on change

The two availability log lines read `self._attr_name`, which would now raise `AttributeError` on the unnamed entities — and on the path that runs whenever a value drops out or comes back, so at the first connection hiccup. They use `self.name` instead, the resolved name, which is what the message was after anyway.

Verified on a running Home Assistant, not just by reading the code. Note that `entity_id`s are unchanged, since HA does not recompute them for already-registered entities — only the displayed names change.

Touches only `sensor.py`, so it is independent of #160 and #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)