### PR TITLE
Stop treating a queued write as a failed one

### DIFF
--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -539,7 +539,7 @@ class Hub(DataUpdateCoordinator):
                                                             _LOGGER.info(
                                                                 "Execution_state waiting execution"
                                                             )
-                                                        if execution_state == 2:
+                                                        elif execution_state == 2:
                                                             _LOGGER.info(
                                                                 "Execution_state in progress"
                                                             )


### PR DESCRIPTION
One-character fix: an `if` that should be an `elif`.

In `set_capability_value`, the execution poller tests state 1 in an `if` of its own, then opens a **fresh** `if`/`elif` chain on state 2:

```python
if execution_state == 1:
    _LOGGER.info("Execution_state waiting execution")

if execution_state == 2:        # new chain
    ...
elif execution_state == 3:
    completed = True
    break
else:                            # state 1 lands here
    _LOGGER.info("Execution_state error")
    break
```

So state 1 — *waiting execution*, the normal first answer to a write — logs `waiting execution`, falls into the `else` of the second chain, logs `Execution_state error` and breaks out.

`completed` stays `False`, so the optimistic `capability["value"] = value` after the loop never runs, and the entity keeps its old value until the next scheduled poll, up to a minute later. Nothing had failed: the write went through.

Closing the chain makes a queued execution fall through to the retry sleep, like an in-progress one:

```
queued then ok    waiting -> waiting -> in progress -> completed
immediate ok      completed
real error        waiting -> ERROR
```

The giveaway in the logs is an `Execution_state waiting execution` followed immediately by `Execution_state error` on a write that visibly succeeded.

Running on my installation: entities now reflect a change as soon as the write completes, instead of waiting for the next poll.

Independent of #160, #161, #162 and #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)