### PR TITLE
Map capability 303 as the room error code

### DIFF
--- a/custom_components/cozytouch/capability.py
+++ b/custom_components/cozytouch/capability.py
@@ -394,6 +394,14 @@ def get_capability_infos(modelInfos: dict, capabilityId: int, capabilityValue: s
         capability["category"] = "sensor"
         capability["icon"] = "mdi:clock-outline"
 
+    elif capabilityId == 303:
+        # ERROR_CODE_ROOM, a matrix the device fills with zeroes when healthy.
+        # Surfaced raw: the list gives the name, not how to read the codes.
+        capability["name"] = "error_code"
+        capability["type"] = "string"
+        capability["category"] = "diag"
+        capability["icon"] = "mdi:alert-circle-outline"
+
     elif capabilityId == 196:
         capability["name"] = "prog_01_z1"
         capability["type"] = "prog"

--- a/custom_components/cozytouch/strings.json
+++ b/custom_components/cozytouch/strings.json
@@ -164,6 +164,7 @@
             }
         },
         "sensor": {
+            "error_code":               { "name": "Error Code" },
             "air_conditioner":          { "name": "Air Conditioner" },
             "away_mode":                { "name": "Away Mode" },
             "away_mode_start":          { "name": "Away Mode Start" },

--- a/custom_components/cozytouch/translations/en.json
+++ b/custom_components/cozytouch/translations/en.json
@@ -164,6 +164,7 @@
             }
         },
         "sensor": {
+            "error_code":               { "name": "Error Code" },
             "air_conditioner":          { "name": "Air Conditioner" },
             "away_mode":                { "name": "Away Mode" },
             "away_mode_start":          { "name": "Away Mode Start" },

--- a/custom_components/cozytouch/translations/fr.json
+++ b/custom_components/cozytouch/translations/fr.json
@@ -164,6 +164,7 @@
             }
         },
         "sensor": {
+            "error_code":               { "name": "Code d'erreur" },
             "air_conditioner":          { "name": "Climatisation" },
             "away_mode":                { "name": "Absence" },
             "away_mode_start":          { "name": "Absence Début" },


### PR DESCRIPTION
Using the capability list @dhuyghe shared in #86.

`303` is `ERROR_CODE_ROOM`. My three rooms report a matrix filled with zeroes, which reads as "nothing wrong", and there was no way to see a fault from HA before this.

Exposed as a diagnostic sensor showing the raw value. The list gives the name, not how to decode the codes, so turning the matrix into a message would be inventing something. A raw value someone can watch is more useful than a wrong interpretation.

### Other names from the list I did not act on

Worth recording, since knowing the name is not the same as knowing the meaning:

- `218 WIFI_CONNECTED` reads `0` on all seven of my devices while the system is plainly online, so the polarity is unclear. A connectivity sensor stuck on "disconnected" would be worse than nothing.
- `102020 AIR_MIXING_ACTUAL_MODE` moves with the system mode rather than with air circulation, which its name does not explain.
- `100260 ABSENCE_ROOM_DATE` and `100261 ABSENCE_ROOM_STATE` mirror the hub absence capabilities the integration already handles, but wiring them into that machinery needs more than a name.

`294 TEMPERATURE_UPDATE_STEP` is worth having too — `climate.py` hardcodes `0.5` while the device states its own granularity — but the natural place to read it sits inside the capability gating from #160, so it is better proposed on top of that once merged.

### The list also settles two things in my other PRs

`102025`/`102026` are `AIR_MIXING_MIN_DURATION`/`MAX_DURATION`, confirming the bounds I had inferred in #163, and `181` is `SERVICE_IN_PROGRESS_MODE`, which is exactly how #160 reads it. Commented on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)